### PR TITLE
Verhelp UserWarning door lib_bamboo

### DIFF
--- a/python/lib_bamboo.py
+++ b/python/lib_bamboo.py
@@ -35,7 +35,7 @@ def prettify(dataframe, type="", columns=None):
         if type == "zwartboek":
             columns.append("overtredingen")
             
-        dataframe["datum"] = dataframe["datum"].dt.strftime("%d-%m-%Y")
+        dataframe.loc[:, ("datum")] = dataframe["datum"].dt.strftime("%d-%m-%Y")
         index = False
 
 

--- a/python/lib_bamboo.py
+++ b/python/lib_bamboo.py
@@ -28,18 +28,19 @@ import math
 from datetime import datetime
 
 def prettify(dataframe, type="", columns=None):
-    
+
+    df = dataframe.copy()
     index = True
     if type == "zwartboek" or type == "eregalerij":
         columns = ["datum", "team1", "team2", "uitslag", "scheidsrechter"]
         if type == "zwartboek":
             columns.append("overtredingen")
             
-        dataframe.loc[:, ("datum")] = dataframe["datum"].dt.strftime("%d-%m-%Y")
+        df["datum"] = dataframe["datum"].dt.strftime("%d-%m-%Y")
         index = False
 
 
-    return dataframe.to_string(columns=columns, index=index, na_rep="0", float_format=round_str)
+    return df.to_string(columns=columns, index=index, na_rep="0", float_format=round_str)
 
 def round_str(num):
     if(math.isnan(num)):


### PR DESCRIPTION
Nadat een student een view had aangemaakt op de data (bijvoorbeeld door `.head(10)` te doen) gaf lib_bamboo een warning bij het aanpassen van de datum die voor de studenten heel cryptisch is.

Ik heb er geen onderzoek naar gedaan, maar dit is waarschijnlijk sinds een recente versie van pandas het geval.

Door gebruik te maken van `.loc()` wordt deze warning verholpen, maar de datum nog steeds wel aangepast.